### PR TITLE
Fix expect assertion

### DIFF
--- a/test/transfer.test.js
+++ b/test/transfer.test.js
@@ -87,7 +87,7 @@ const options = {
           .balanceOf(fromAddress)
           .call({ from: fromAddress })
           .then(result => {
-            expect(result.balance).to.eql(totalSupplyQty);
+            expect(result).to.eql(totalSupplyQty);
             return token;
           });
       };
@@ -124,7 +124,7 @@ const options = {
           .call({ from: fromAddress })
           .then(result => {
             const remainingQty = totalSupplyQty - transferQty;
-            expect(result.balance).to.eql(remainingQty);
+            expect(result).to.eql(remainingQty);
             return token;
           });
       };


### PR DESCRIPTION
Currently when running tests against the latest `quorum-examples/examples/7nodes` on `master` using `raft` with `tessera` (https://github.com/jpmorganchase/quorum-examples/tree/master), there are 4 tests broken:

```
4 passing (1s)
  4 failing

  1) Http
       Human Standard Contract
         can approve allowance and fetch events:
     Error: expected '0' to sort of equal 100
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.allowance.call.then.approvedResult (test/allowance.test.js:114:42)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

  2) Ipc
       Human Standard Contract
         can approve allowance and fetch events:
     Error: expected '0' to sort of equal 100
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.allowance.call.then.approvedResult (test/allowance.test.js:114:42)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

  3) Http
       Human Standard Contract
         can transfer funds with private payload:
     Error: expected undefined to sort of equal 99840
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.balanceOf.call.then.result (test/transfer.test.js:127:39)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

  4) Ipc
       Human Standard Contract
         can transfer funds with private payload:
     Error: expected undefined to sort of equal 99840
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.balanceOf.call.then.result (test/transfer.test.js:127:39)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)
```

This assertion fix returns an expected integer value rather than `undefined`, but the tests are still broken as follows:

```
4 passing (2s)
  4 failing

  1) Http
       Human Standard Contract
         can approve allowance and fetch events:
     Error: expected '0' to sort of equal 100
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.allowance.call.then.approvedResult (test/allowance.test.js:114:42)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

  2) Ipc
       Human Standard Contract
         can approve allowance and fetch events:
     Error: expected '0' to sort of equal 100
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.allowance.call.then.approvedResult (test/allowance.test.js:114:42)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

  3) Http
       Human Standard Contract
         can transfer funds with private payload:
     Error: expected '100000' to sort of equal 99840
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.balanceOf.call.then.result (test/transfer.test.js:127:31)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

  4) Ipc
       Human Standard Contract
         can transfer funds with private payload:
     Error: expected '100000' to sort of equal 99840
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at token.methods.balanceOf.call.then.result (test/transfer.test.js:127:31)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)
```

As an aside, these failing tests seem to imply that the `RawTransactionManager` or some other intermediary is acting as the `msg.sender` in the `sendRawTransaction` s, and as a result the expected sender (`fromAddress`) is not actually approving or transferring tokens.