### PR TITLE
Remove unused Web3 declaration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const RawTransactionManager = require('./rawTransactionManager');
-const Web3 = require('web3');
 
 const _ = require('underscore');
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "web3",
     "quorum",
     "tessera",
-    "constelation"
+    "constellation"
   ],
   "dependencies": {
     "dotenv": "^6.2.0",


### PR DESCRIPTION
Web3 is imported by Quorum.js but never used. This is because all instances of web3 are passed into the extension methods or transaction managers.

Also fixes a typo in the package tags.