### PR TITLE
Fix lint issues and make API prefixing consistent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,50 +129,59 @@ const extend = function (web3, apis) {
   }
 
   if (allApis || apis.includes('istanbul')) {
-    const prefix = 'istanbul_';
-
-    const methods = [{
-      name: 'getSnapshot',
-      call: `${prefix}getSnapshot`,
-      params: 1
-    }, {
-      name: 'getSnapshotAtHash',
-      call: `${prefix}getSnapshotAtHash`,
-      params: 1
-    }, {
-      name: 'getValidators',
-      call: `${prefix}getValidators`,
-      params: 1
-    }, {
-      name: 'getValidatorsAtHash',
-      call: `${prefix}getValidatorsAtHash`,
-      params: 1
-    }, {
-      name: 'propose',
-      call: `${prefix}propose`,
-      params: 2
-    }, {
-      name: 'discard',
-      call: `${prefix}discard`,
-      params: 1
-    }, {
-      name: 'getSignersFromBlock',
-      call: `${prefix}getSignersFromBlock`,
-      params: 1,
-      inputFormatter: [web3.extend.formatters.inputBlockNumberFormatter]
-    }, {
-      name: 'getSignersFromBlockByHash',
-      call: `${prefix}getSignersFromBlockByHash`,
-      params: 1
-    }, {
-      name: 'candidates',
-      call: `${prefix}candidates`,
-      params: 0
-    }, {
-      name: 'nodeAddress',
-      call: `${prefix}nodeAddress`,
-      params: 0
-    }];
+    const methods = [
+      {
+        name: 'getSnapshot',
+        call: 'istanbul_getSnapshot',
+        params: 1
+      },
+      {
+        name: 'getSnapshotAtHash',
+        call: 'istanbul_getSnapshotAtHash',
+        params: 1
+      },
+      {
+        name: 'getValidators',
+        call: 'istanbul_getValidators',
+        params: 1
+      },
+      {
+        name: 'getValidatorsAtHash',
+        call: 'istanbul_getValidatorsAtHash',
+        params: 1
+      },
+      {
+        name: 'propose',
+        call: 'istanbul_propose',
+        params: 2
+      },
+      {
+        name: 'discard',
+        call: 'istanbul_discard',
+        params: 1
+      },
+      {
+        name: 'getSignersFromBlock',
+        call: 'istanbul_getSignersFromBlock',
+        params: 1,
+        inputFormatter: [web3.extend.formatters.inputBlockNumberFormatter]
+      },
+      {
+        name: 'getSignersFromBlockByHash',
+        call: 'istanbul_getSignersFromBlockByHash',
+        params: 1
+      },
+      {
+        name: 'candidates',
+        call: 'istanbul_candidates',
+        params: 0
+      },
+      {
+        name: 'nodeAddress',
+        call: 'istanbul_nodeAddress',
+        params: 0
+      }
+    ];
 
     web3.extend({
       property: 'istanbul',


### PR DESCRIPTION
Put the API namespace directly in the named calls, which keeps it consistent with all the other API definitions. API namespaces are also unlikely to change often (if ever), so hardcoding them in the API will force the developer to think about whether they should be changing the prefix instead of haphazardly updating a single variable.

Also updates some linting issue relating to object definition positions (opening brace on newline) on the affected lines.

The alternative would be to change the other APIs to use a prefix, but imo that makes the `call` harder to read.

note: the linter actually prefers double quotes for strings, but I kept it consistent with the rest of the codebase for now