### PR TITLE
add HTTP header from Web3 when calling eth_sendRawPrivateTransaction

### DIFF
--- a/lib/enclave/generic.js
+++ b/lib/enclave/generic.js
@@ -74,6 +74,7 @@ module.exports = (web3, ipcPath, publicUrl, privateUrl, tlsSettings) => {
       method: "POST",
       // eslint-disable-next-line no-underscore-dangle
       uri: web3.eth.currentProvider.host,
+      headers: web3.eth.currentProvider.headers,
       json: true,
       body: {
         jsonrpc: "2.0",


### PR DESCRIPTION
This is make sure the call carrying same HTTP Headers configured via Web3
E.g.: via `Web3('http://localhost:8454', headers)`